### PR TITLE
Add percent- and format-option to mlabel scatter plot

### DIFF
--- a/installation/streamplot.ado
+++ b/installation/streamplot.ado
@@ -252,10 +252,13 @@ colorpalette `mycolor', n(`numcolor') nograph
 	local x0 =  `x'
 	local x1 =  `x' + 1
 
+	if "`ylabcolor'" == "palette" {
+		local ycolor  "`r(p`x1')'"
+	}
 
 	local areagraph `areagraph' rarea stack_`yvar'`x0'_norm stack_`yvar'`x1'_norm `xvar', fcolor("`r(p`x1')'") fi(100) lcolor(`linec') lwidth(`linew') ||
 	
-	local labels    `labels'  (scatter y`yvar'`x1' `xvar' if last==1, mlabel(label`x1'_`yvar') mcolor(none) mlabsize(`ylabsize') mlabcolor(`ylabcolor')) || 			
+	local labels    `labels'  (scatter y`yvar'`x1' `xvar' if last==1, mlabel(label`x1'_`yvar') mcolor(none) mlabsize(`ylabsize') mlabcolor(`ycolor')) || 			
 		
 
 	}

--- a/installation/streamplot.ado
+++ b/installation/streamplot.ado
@@ -26,7 +26,7 @@ version 15
 		[ LColor(string)  LWidth(string) labcond(string) ] 		///					
 		[ YLABSize(real 1.4) YLABel(varname)  YLABColor(string) offset(real 0.12)    ] ///
 		[ xlabel(passthru) xtitle(passthru) title(passthru) subtitle(passthru) note(passthru) scheme(passthru) name(passthru) xsize(passthru) ysize(passthru)  ] ///
-		[  allopt graphopts(string asis) PERCENT * ] 
+		[  allopt graphopts(string asis) PERCENT FORMAT(string) * ] 
 		
 		
 		
@@ -39,7 +39,14 @@ version 15
 	
 	marksample touse, strok
 	gettoken yvar xvar : varlist 	
-	
+
+
+* Definition  of locals - Default format
+if `"`format'"' == "" {
+local format "%12.0f"	
+}
+
+
 qui {
 preserve	
 		
@@ -49,7 +56,8 @@ preserve
 			exit
 		}
 		
-		
+
+
 		
 	// prepare the dataset	
 	collapse (sum) `yvar' if `touse', by(`xvar' `by')
@@ -179,12 +187,12 @@ drop lastsum*
 				local condition 
 			}
 		
-	* Add percent-option
+		   * Addition of percent and format
 		   if `"`percent'"'!="" {
-			local ylabvalues `"string(`yvar'`x'_share, , "%12.0f") + "%""'
+			local ylabvalues `"string(`yvar'`x'_share, `"`format'"') + "%""'
 		   }
 		   else {
-			local ylabvalues `"string(`yvar'`x', , "%12.0f")"'
+			local ylabvalues `"string(`yvar'`x', `"`format'"')"'
 		   }
 
 		local t : var lab `yvar'`x'

--- a/installation/streamplot.ado
+++ b/installation/streamplot.ado
@@ -26,7 +26,7 @@ version 15
 		[ LColor(string)  LWidth(string) labcond(string) ] 		///					
 		[ YLABSize(real 1.4) YLABel(varname)  YLABColor(string) offset(real 0.12)    ] ///
 		[ xlabel(passthru) xtitle(passthru) title(passthru) subtitle(passthru) note(passthru) scheme(passthru) name(passthru) xsize(passthru) ysize(passthru)  ] ///
-		[  allopt graphopts(string asis) * ] 
+		[  allopt graphopts(string asis) PERCENT * ] 
 		
 		
 		
@@ -179,10 +179,17 @@ drop lastsum*
 				local condition 
 			}
 		
+	* Add percent-option
+		   if `"`percent'"'!="" {
+			local ylabvalues `"string(`yvar'`x'_share, , "%12.0f") + "%""'
+		   }
+		   else {
+			local ylabvalues `"string(`yvar'`x', , "%12.0f")"'
+		   }
 
 		local t : var lab `yvar'`x'
-		gen label`x'_`yvar'  = "`t'" + " (" + string( `yvar'`x', "%12.0f") + ")"	if last==1  `condition'
-		
+		gen label`x'_`yvar'  = "`t'" + " (" + `ylabvalues' + ")"	if last==1  `condition' // 
+
 	}
 
 


### PR DESCRIPTION
I like to have the percent rather than the values of the last period in the marker label. So I add the percent option and add manipulate the local for creating the label

See issue #3 -