### PR TITLE
Graph name is added to graph options

### DIFF
--- a/installation/streamplot.ado
+++ b/installation/streamplot.ado
@@ -273,7 +273,8 @@ colorpalette `mycolor', n(`numcolor') nograph
 				ytitle("") `xtitle'  ///
 				ylabel(`ymin' `ymax', nolabels noticks nogrid) ///
 				`xlabel' xscale(range(`xrmin' `xrmax'))   ///  
-				`title' `subtitle' `note' `scheme' `xsize' `ysize'
+				`title' `subtitle' `note' `scheme' `xsize' `ysize' ///
+				`name'
 
 restore
 }		


### PR DESCRIPTION
Graph name can be specified but was not included as macro in graph options. So graph was not named despite name was specified. see issue #10